### PR TITLE
Fix formSelect component's default option

### DIFF
--- a/src/components/form-select/index.js
+++ b/src/components/form-select/index.js
@@ -8,7 +8,7 @@ export default {
   replace: true,
   computed: {
     allOptions(){
-        if (this.defaultOption.length) {
+        if (this.defaultOption.text && this.defaultOption.value) {
             return [this.defaultOption].concat(this.options)
         }
         return this.options


### PR DESCRIPTION
When adding using the `default-option` directive you would need to have added a `length` property with a truthy value to successfully add the default option. This change fixes that by making sure there is a default option with a text and value property.
